### PR TITLE
Add --output flag to specify target directory

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -66,6 +66,10 @@ pub struct NewArgs {
     #[arg(value_name = "NAME")]
     pub name: String,
 
+    /// Output directory (defaults to project name)
+    #[arg(short, long, value_name = "DIR")]
+    pub output: Option<PathBuf>,
+
     /// Domain for the operator (e.g., example.com)
     #[arg(short, long, default_value = "example.com")]
     pub domain: String,
@@ -268,6 +272,44 @@ mod tests {
             assert_eq!(args.name, "my-operator");
             assert_eq!(args.domain, "mycompany.io");
             assert!(args.dry_run);
+        } else {
+            panic!("Expected New command");
+        }
+    }
+
+    #[test]
+    fn test_parse_new_with_output() {
+        let cli = Cli::parse_from([
+            "kubegen",
+            "new",
+            "my-operator",
+            "--output",
+            "/path/to/output",
+        ]);
+        if let Commands::New(args) = cli.command {
+            assert_eq!(args.name, "my-operator");
+            assert_eq!(args.output, Some(PathBuf::from("/path/to/output")));
+        } else {
+            panic!("Expected New command");
+        }
+    }
+
+    #[test]
+    fn test_parse_new_with_output_short() {
+        let cli = Cli::parse_from(["kubegen", "new", "my-operator", "-o", "./custom-dir"]);
+        if let Commands::New(args) = cli.command {
+            assert_eq!(args.name, "my-operator");
+            assert_eq!(args.output, Some(PathBuf::from("./custom-dir")));
+        } else {
+            panic!("Expected New command");
+        }
+    }
+
+    #[test]
+    fn test_parse_new_without_output() {
+        let cli = Cli::parse_from(["kubegen", "new", "my-operator"]);
+        if let Commands::New(args) = cli.command {
+            assert!(args.output.is_none());
         } else {
             panic!("Expected New command");
         }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -40,16 +40,21 @@ pub fn execute_new(args: &NewArgs, template_dir: Option<&Path>) -> Result<()> {
         })?;
 
     let template_ctx = project_ctx.to_template_context();
-    let project_dir = Path::new(&args.name);
+
+    // Use --output directory if specified, otherwise use project name
+    let project_dir = args
+        .output
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from(&args.name));
 
     if args.dry_run {
-        return execute_dry_run(project_dir, &template_ctx, template_dir);
+        return execute_dry_run(&project_dir, &template_ctx, template_dir);
     }
 
     let write_opts = WriteOptions::with_force(args.force);
 
     // Check for conflicts before proceeding
-    let paths_to_create = get_paths_to_create(project_dir);
+    let paths_to_create = get_paths_to_create(&project_dir);
     let conflicts = check_conflicts(&paths_to_create, &write_opts);
     if !conflicts.is_empty() {
         return Err(crate::error::KubegenError::ValidationError(
@@ -58,11 +63,11 @@ pub fn execute_new(args: &NewArgs, template_dir: Option<&Path>) -> Result<()> {
     }
 
     // Create project structure
-    create_project_structure(project_dir, &template_ctx, &write_opts, template_dir)?;
+    create_project_structure(&project_dir, &template_ctx, &write_opts, template_dir)?;
 
     info!("Project '{}' created successfully!", args.name);
     info!("Next steps:");
-    info!("  cd {}", args.name);
+    info!("  cd {}", project_dir.display());
     info!("  cargo build");
     info!("  kubegen add crd MyResource --group {}", args.domain);
 
@@ -198,6 +203,7 @@ mod tests {
     fn make_args(name: &str) -> NewArgs {
         NewArgs {
             name: name.to_string(),
+            output: None,
             domain: "example.com".to_string(),
             non_interactive: true,
             dry_run: false,
@@ -311,6 +317,7 @@ mod tests {
     fn test_execute_new_invalid_name() {
         let args = NewArgs {
             name: "Invalid Name".to_string(), // Contains space
+            output: None,
             domain: "example.com".to_string(),
             non_interactive: true,
             dry_run: false,


### PR DESCRIPTION
## Summary
- Adds `-o/--output` flag to `kubegen new` command
- Allows specifying a different output directory from the project name
- Project name is preserved in Cargo.toml while files are created in the specified directory

## Usage
```bash
# Create project in custom directory
kubegen new my-operator --output /path/to/output

# Short form
kubegen new my-operator -o ./custom-dir
```

## Test plan
- [x] CLI parsing tests for --output flag
- [x] Manual testing with various paths
- [x] All existing tests pass
- [x] Clippy clean

Closes #164